### PR TITLE
just reduce/pretty code and set go version to go1.16+ in go.mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ _testmain.go
 *.exe
 tags
 environ
+
+.env
+.envrc

--- a/bind.go
+++ b/bind.go
@@ -22,10 +22,10 @@ const (
 )
 
 var defaultBinds = map[int][]string{
-	DOLLAR:   []string{"postgres", "pgx", "pq-timeouts", "cloudsqlpostgres", "ql", "nrpostgres", "cockroach"},
-	QUESTION: []string{"mysql", "sqlite3", "nrmysql", "nrsqlite3"},
-	NAMED:    []string{"oci8", "ora", "goracle", "godror"},
-	AT:       []string{"sqlserver"},
+	DOLLAR:   {"postgres", "pgx", "pq-timeouts", "cloudsqlpostgres", "ql", "nrpostgres", "cockroach"},
+	QUESTION: {"mysql", "sqlite3", "nrmysql", "nrsqlite3"},
+	NAMED:    {"oci8", "ora", "goracle", "godror"},
+	AT:       {"sqlserver"},
 }
 
 var binds sync.Map

--- a/doc.go
+++ b/doc.go
@@ -8,5 +8,4 @@
 // Additions include scanning into structs, named query support, rebinding
 // queries for different drivers, convenient shorthands for common error handling
 // and more.
-//
 package sqlx

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-sqlx/sqlx
 
-go 1.10
+go 1.16
 
 require (
 	github.com/go-sql-driver/mysql v1.7.1

--- a/named_context.go
+++ b/named_context.go
@@ -1,5 +1,3 @@
-// +build go1.8
-
 package sqlx
 
 import (

--- a/named_context_test.go
+++ b/named_context_test.go
@@ -1,5 +1,3 @@
-// +build go1.8
-
 package sqlx
 
 import (

--- a/reflectx/reflect.go
+++ b/reflectx/reflect.go
@@ -3,7 +3,6 @@
 // allows for Go-compatible named attribute access, including accessing embedded
 // struct attributes and the ability to use  functions and struct tags to
 // customize field names.
-//
 package reflectx
 
 import (

--- a/sqlx.go
+++ b/sqlx.go
@@ -5,8 +5,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
-
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -706,7 +705,7 @@ func LoadFile(e Execer, path string) (*sql.Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	contents, err := ioutil.ReadFile(realpath)
+	contents, err := os.ReadFile(realpath)
 	if err != nil {
 		return nil, err
 	}

--- a/sqlx_context.go
+++ b/sqlx_context.go
@@ -1,12 +1,10 @@
-// +build go1.8
-
 package sqlx
 
 import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 )
@@ -99,7 +97,7 @@ func LoadFileContext(ctx context.Context, e ExecerContext, path string) (*sql.Re
 	if err != nil {
 		return nil, err
 	}
-	contents, err := ioutil.ReadFile(realpath)
+	contents, err := os.ReadFile(realpath)
 	if err != nil {
 		return nil, err
 	}

--- a/sqlx_context_test.go
+++ b/sqlx_context_test.go
@@ -1,6 +1,3 @@
-//go:build go1.8
-// +build go1.8
-
 // The following environment variables, if set, will be used:
 //
 //   - SQLX_SQLITE_DSN

--- a/types/types.go
+++ b/types/types.go
@@ -6,8 +6,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
-
-	"io/ioutil"
+	"io"
 )
 
 // GzippedText is a []byte which transparently gzips data being submitted to
@@ -43,7 +42,7 @@ func (g *GzippedText) Scan(src interface{}) error {
 		return err
 	}
 	defer reader.Close()
-	b, err := ioutil.ReadAll(reader)
+	b, err := io.ReadAll(reader)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* set go version to go 1.16 in go.mod
  > because `ioutil.ReadFile(...)`/`ioutil.ReadAll` are deprecated since go 1.16 so use minimum go version is set to 1.16(now go is go1.20+, so use go1.16+ is well)
* reduce and pretty some source code
  > no need `// +build go1.8` build tag because go version minimum support is go1.16+