### PR TITLE
Support pgx versioned names

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -22,7 +22,7 @@ const (
 )
 
 var defaultBinds = map[int][]string{
-	DOLLAR:   []string{"postgres", "pgx", "pq-timeouts", "cloudsqlpostgres", "ql", "nrpostgres", "cockroach"},
+	DOLLAR:   []string{"postgres", "pgx", "pgx/v4", "pgx/v5", "pq-timeouts", "cloudsqlpostgres", "ql", "nrpostgres", "cockroach"},
 	QUESTION: []string{"mysql", "sqlite3", "nrmysql", "nrsqlite3"},
 	NAMED:    []string{"oci8", "ora", "goracle", "godror"},
 	AT:       []string{"sqlserver"},

--- a/bind_test.go
+++ b/bind_test.go
@@ -7,7 +7,7 @@ import (
 
 func oldBindType(driverName string) int {
 	switch driverName {
-	case "postgres", "pgx", "pq-timeouts", "cloudsqlpostgres", "ql":
+	case "postgres", "pgx", "pgx/v4", "pgx/v5", "pq-timeouts", "cloudsqlpostgres", "ql":
 		return DOLLAR
 	case "mysql":
 		return QUESTION


### PR DESCRIPTION
### Description

This commit supports the driver names pgx/v4 and pgx/v5. These aliases of different versions of pgx allow loading the proper driver if a project's dependency imports a different one.

This PR was previously sent to https://github.com/jmoiron/sqlx/pull/868

cc: @BenKnigge 