### PR TITLE
fix: handling named parameter in string literals

### DIFF
--- a/named_test.go
+++ b/named_test.go
@@ -53,6 +53,30 @@ func TestCompileQuery(t *testing.T) {
 			T: `SELECT @name := "name", @p1, @p2, @p3`,
 			V: []string{"age", "first", "last"},
 		},
+		{
+			Q: `SELECT * FROM users WHERE id = :id AND name = ':name'`,
+			R: `SELECT * FROM users WHERE id = ? AND name = ':name'`,
+			D: `SELECT * FROM users WHERE id = $1 AND name = ':name'`,
+			T: `SELECT * FROM users WHERE id = @p1 AND name = ':name'`,
+			N: `SELECT * FROM users WHERE id = :id AND name = ':name'`,
+			V: []string{"id"},
+		},
+		{
+			Q: `SELECT * FROM users WHERE id = :id AND name = '":name"'`,
+			R: `SELECT * FROM users WHERE id = ? AND name = '":name"'`,
+			D: `SELECT * FROM users WHERE id = $1 AND name = '":name"'`,
+			T: `SELECT * FROM users WHERE id = @p1 AND name = '":name"'`,
+			N: `SELECT * FROM users WHERE id = :id AND name = '":name"'`,
+			V: []string{"id"},
+		},
+		{
+			Q: `SELECT * FROM users WHERE id = :id AND name = '\':name\''`,
+			R: `SELECT * FROM users WHERE id = ? AND name = '\':name\''`,
+			D: `SELECT * FROM users WHERE id = $1 AND name = '\':name\''`,
+			T: `SELECT * FROM users WHERE id = @p1 AND name = '\':name\''`,
+			N: `SELECT * FROM users WHERE id = :id AND name = '\':name\''`,
+			V: []string{"id"},
+		},
 		/* This unicode awareness test sadly fails, because of our byte-wise worldview.
 		 * We could certainly iterate by Rune instead, though it's a great deal slower,
 		 * it's probably the RightWay(tm)


### PR DESCRIPTION
## fix
- https://github.com/go-sqlx/sqlx/issues/19

## description
This PR introduces improvements to the handling of colons within string literals in SQL query parsing and ensures backward compatibility with existing codebases and database queries. It addresses issues where colons inside string literals were incorrectly interpreted as named parameters, leading to query parsing errors.

## changes
- Implemented logic to detect the start and end of string literals, ensuring colons within these literals are correctly identified and not treated as part of named parameters.
- Added an escaping mechanism for colons that appear as part of string literals, allowing for explicit differentiation between literal colons and named parameter indicators.
- Ensured that the new parsing logic retains backward ([this case](https://github.com/go-sqlx/sqlx/blob/80a60b792148cf998cd73bd17d3a88a94d07fe3b/named_test.go#L41))compatibility by accurately processing existing queries with colons in string literals, including those with escaped colons.